### PR TITLE
Improved compatibility of array class with STL

### DIFF
--- a/Array.cc
+++ b/Array.cc
@@ -1,10 +1,11 @@
+#include <algorithm>
+#include <numeric>
 #include <math.h>
 
 // Turning off argument checking with -DNDEBUG improves optimization.
 
 #include "Array.h"
 using namespace Array;
-using namespace std;
 
 int n=2,m=3,p=4;
 
@@ -12,6 +13,7 @@ typedef array1<double>::opt vector;
 typedef Array1<double>::opt Vector;
 
 using std::cout;
+using std::endl;
 
 void f(double *x) {cout << x[0] << endl; return;}
 
@@ -87,5 +89,10 @@ int main()
 
   cout << D << endl;
   
+  Array2<double>::iterator result = std::max_element(A.begin(), A.end());
+  cout << *result << endl;
+
+  cout << std::accumulate(D.begin(),D.end(),0) << endl;
+
   return 0;
 }

--- a/Array.h
+++ b/Array.h
@@ -171,7 +171,7 @@ public:
       state=unallocated;
     }
   }
-  virtual void Dimension(unsigned int nx0) {size=nx0;}
+  void Dimension(unsigned int nx0) {size=nx0;}
 
   void Dimension(unsigned int nx0, T *v0) {
     Dimension(nx0); v=v0; clear(allocated);
@@ -210,8 +210,8 @@ public:
   void Hold() {if(test(allocated)) {state=temporary;}}
   void Purge() const {if(test(temporary)) {Deallocate(); state=unallocated;}}
         
-  virtual void Check(int i, int n, unsigned int dim, unsigned int m,
-                     int o=0) const {
+  void Check(int i, int n, unsigned int dim, unsigned int m,
+             int o=0) const {
     if(i < 0 || i >= n) {
       std::ostringstream buf;
       buf << "Array" << dim << " index ";

--- a/Array.h
+++ b/Array.h
@@ -757,7 +757,7 @@ public: // iterator geters
   { return const_iterator(array1<T>::v); }
   
   const_iterator cend() const noexcept
-  { return const_iterator(array1<T>::v + array1<T>::size); }
+  { return const_iterator(array1<T>::v + array1<T>::_size); }
   #endif
 
   const_reverse_iterator rbegin() const
@@ -774,7 +774,7 @@ public: // iterator geters
 
   #if __cplusplus >= 201103L
   const_reverse_iterator crbegin() const noexcept
-  { return const_reverse_iterator(array1<T>::v + array1<T>::size); }
+  { return const_reverse_iterator(array1<T>::v + array1<T>::_size); }
 
   const_reverse_iterator crend() const noexcept
   { return const_reverse_iterator(array1<T>::v); }

--- a/Array.h
+++ b/Array.h
@@ -29,7 +29,7 @@
 #include <climits>
 #include <cstdlib>
 #include <cerrno>
-#if __cplusplus => 201103L
+#if __cplusplus >= 201103L
 #include <initializer_list>
 #endif
 
@@ -133,7 +133,7 @@ protected:
   mutable int state;
 public:
 
-#if __cplusplus => 201103L
+#if __cplusplus >= 201103L
   /**
    * @brief array1 initializing constructur using initializer list
    * @param il initializer list
@@ -559,70 +559,70 @@ private: // abstract iterator prototypes
 
         virtual inline const abstract_iterator
         operator+(const std::ptrdiff_t& n) const
-        #if __cplusplus == 201103L
+        #if __cplusplus >= 201103L
         final
         #endif
         { return abstract_iterator::operator-(n); }
 
         virtual inline abstract_iterator operator++()
-        #if __cplusplus == 201103L
+        #if __cplusplus >= 201103L
         final
         #endif
         { return abstract_iterator::operator--(); }
 
         virtual inline abstract_iterator operator++(int)
-        #if __cplusplus == 201103L
+        #if __cplusplus >= 201103L
         final
         #endif
         { return abstract_iterator::operator--(0); }
 
         virtual inline abstract_iterator
         operator-=(const std::ptrdiff_t& n)
-        #if __cplusplus == 201103L
+        #if __cplusplus >= 201103L
         final
         #endif
         { return abstract_iterator::operator +=(n); }
 
         virtual inline abstract_iterator operator--()
-        #if __cplusplus == 201103L
+        #if __cplusplus >= 201103L
         final
         #endif
         { return abstract_iterator::operator ++(); }
 
         virtual inline abstract_iterator operator--(int)
-        #if __cplusplus == 201103L
+        #if __cplusplus >= 201103L
         final
         #endif
         { return abstract_iterator::operator ++(0); }
 
         virtual inline const abstract_iterator
         operator-(const std::ptrdiff_t& n) const
-        #if __cplusplus == 201103L
+        #if __cplusplus >= 201103L
         final
         #endif
         { return abstract_iterator::operator+(n); }
 
     public: // comparission operators
         inline bool operator>(const abstract_iterator& other)
-        #if __cplusplus == 201103L
+        #if __cplusplus >= 201103L
         final
         #endif
         { return abstract_iterator::operator<(other); }
 
         inline bool operator<(const abstract_iterator& other)
-        #if __cplusplus == 201103L
+        #if __cplusplus >= 201103L
         final
         #endif
         { return abstract_iterator::operator>(other); }
 
         inline bool operator>=(const abstract_iterator& other)
-        #if __cplusplus == 201103L
+        #if __cplusplus >= 201103L
         final
         #endif
         { return abstract_iterator::operator<=(other); }
 
         inline bool operator<=(const abstract_iterator& other)
-        #if __cplusplus == 201103L
+        #if __cplusplus >= 201103L
         final
         #endif
         { return abstract_iterator::operator>=(other); }
@@ -717,42 +717,42 @@ public: // actual iterators
 
 public: // iterator geters
   iterator begin()
-  #if __cplusplus == 201103L
+  #if __cplusplus >= 201103L
   noexcept
   #endif
   { return iterator(array1<T>::v); }
 
   iterator end()
-  #if __cplusplus == 201103L
+  #if __cplusplus >= 201103L
   noexcept
   #endif
   { return iterator(array1<T>::v + array1<T>::_size); }
 
   reverse_iterator rbegin()
-  #if __cplusplus == 201103L
+  #if __cplusplus >= 201103L
   noexcept
   #endif
   { return reverse_iterator(array1<T>::v + array1<T>::_size); }
 
   reverse_iterator rend()
-  #if __cplusplus == 201103L
+  #if __cplusplus >= 201103L
   noexcept
   #endif
   { return reverse_iterator(array1<T>::v); }
 
   const_iterator begin() const
-  #if __cplusplus == 201103L
+  #if __cplusplus >= 201103L
   noexcept
   #endif
   { return const_iterator(array1<T>::v); }
 
   const_iterator end() const
-  #if __cplusplus == 201103L
+  #if __cplusplus >= 201103L
   noexcept
   #endif
   { return const_iterator(array1<T>::v + array1<T>::_size); }
 
-  #if __cplusplus == 201103L
+  #if __cplusplus >= 201103L
   const_iterator cbegin() const noexcept
   { return const_iterator(array1<T>::v); }
   
@@ -761,18 +761,18 @@ public: // iterator geters
   #endif
 
   const_reverse_iterator rbegin() const
-  #if __cplusplus == 201103L
+  #if __cplusplus >= 201103L
   noexcept
   #endif
   { return const_reverse_iterator(array1<T>::v + array1<T>::_size); }
 
   const_reverse_iterator rend() const
-  #if __cplusplus == 201103L
+  #if __cplusplus >= 201103L
   noexcept
   #endif
   { return const_reverse_iterator(array1<T>::v); }
 
-  #if __cplusplus == 201103L
+  #if __cplusplus >= 201103L
   const_reverse_iterator crbegin() const noexcept
   { return const_reverse_iterator(array1<T>::v + array1<T>::size); }
 

--- a/Array.h
+++ b/Array.h
@@ -1,5 +1,6 @@
 /* Array.h:  A high-performance multi-dimensional C++ array class
    Copyright (C) 1997-2016 John C. Bowman, University of Alberta
+   Copyright (C) 2018 Patrik Schoenfeldt, Karlsruhe Institute of Technology
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -368,8 +369,366 @@ public:
     }
     return norm;
   }
-#endif  
-};
+#endif
+private: // abstract iterator prototypes
+  /**
+   * @brief The NDarray1::abstract_iterator class serves
+   *  as base class for NDarray1::const_iterator, NDarray1::iterator,
+   *  and NDarray1::const_iterator
+   */
+  class abstract_iterator
+  {
+  public:
+    /**
+     * @brief value_type std::iterator_traits::value_type
+     */
+    typedef T value_type;
+
+    /**
+     * @brief reference std::iterator_traits::reference
+     */
+    typedef T& reference;
+
+    /**
+     * @brief pointer std::iterator_traits::pointer
+     */
+    typedef T* pointer;
+
+    /**
+     * @brief iterator_category std::iterator_traits::iterator_category
+     */
+    typedef std::random_access_iterator_tag iterator_category;
+
+    /**
+     * @brief difference_type std::iterator_traits::difference_type
+     */
+    typedef std::ptrdiff_t difference_type;
+
+    friend void swap(abstract_iterator& lhs, abstract_iterator& rhs)
+    { std::swap(lhs._ptr,rhs._ptr); }
+
+    /**
+     * @brief operator =
+     * @param other
+     * @return
+     */
+    abstract_iterator& operator=(abstract_iterator& other)
+    { swap(*this, other); return *this; }
+
+    /* constructors are marked protected,
+     * so that no abstract_iterator is constructed */
+  protected:
+    /**
+     * @brief abstract_iterator default and initializing constructors
+     * @param ptr
+     */
+    abstract_iterator(T* ptr=nullptr) : _ptr(ptr) {}
+
+  public: // arithmetic operators
+    virtual inline abstract_iterator
+    operator+=(const std::ptrdiff_t& n)
+    { _ptr += n; return *this; }
+
+    virtual inline const abstract_iterator
+    operator+(const std::ptrdiff_t& n) const
+    { return abstract_iterator(*this) += n; }
+
+    virtual inline abstract_iterator operator++()
+    { _ptr++; return *this; }
+
+    virtual inline abstract_iterator operator++(int)
+    { abstract_iterator i = *this; _ptr++; return i; }
+
+    virtual inline abstract_iterator operator-=(const std::ptrdiff_t& n)
+    { _ptr -= n; return *this; }
+
+    virtual inline abstract_iterator operator--()
+    { _ptr--; return *this; }
+
+    virtual inline abstract_iterator operator--(int)
+    { abstract_iterator i = *this; _ptr--; return i; }
+
+    virtual inline const abstract_iterator
+    operator-(const std::ptrdiff_t& n) const
+    { return abstract_iterator(*this) -= n; }
+
+    friend inline const abstract_iterator&
+    operator+( const std::ptrdiff_t& lhs, const abstract_iterator& rhs)
+    { return rhs+lhs; }
+
+    friend inline const abstract_iterator
+    operator-( const std::ptrdiff_t& lhs, const abstract_iterator& rhs)
+    { return rhs-lhs; }
+
+  public: // comparission operators
+    inline bool operator==(const abstract_iterator& other)
+    { return _ptr == other._ptr; }
+
+    inline bool operator!=(const abstract_iterator& other)
+    { return !(*this == other); }
+
+    virtual inline bool operator>(const abstract_iterator& other)
+    { return _ptr > other._ptr; }
+
+    virtual inline bool operator<(const abstract_iterator& other)
+    { return _ptr < other._ptr; }
+
+    virtual inline bool operator>=(const abstract_iterator& other)
+    { return !operator<(other); }
+
+    virtual inline bool operator<=(const abstract_iterator& other)
+    { return !operator>(other); }
+
+  public:
+    /* access operators (const and non-const iterators use them) */
+    inline const T& operator[](std::ptrdiff_t& n) const
+    { return *(abstract_iterator::_ptr + n); }
+
+    inline const T& operator*() const
+    { return *abstract_iterator::_ptr; }
+
+    inline const T* operator->() const
+    { return abstract_iterator::_ptr; }
+
+  protected:
+    T* _ptr;
+  };
+
+  class abstract_reverse_iterator: public abstract_iterator
+  {
+  protected:
+      // default and initializing constructors
+      abstract_reverse_iterator(T* ptr=nullptr)
+          : abstract_iterator((ptr==nullptr)?nullptr:ptr-1) {}
+
+  public:
+    virtual inline abstract_iterator
+    operator+=(const std::ptrdiff_t& n)
+        { return abstract_iterator::operator -=(n); }
+
+        virtual inline const abstract_iterator
+        operator+(const std::ptrdiff_t& n) const
+        #if __cplusplus == 201103L
+        final
+        #endif
+        { return abstract_iterator::operator-(n); }
+
+        virtual inline abstract_iterator operator++()
+        #if __cplusplus == 201103L
+        final
+        #endif
+        { return abstract_iterator::operator--(); }
+
+        virtual inline abstract_iterator operator++(int)
+        #if __cplusplus == 201103L
+        final
+        #endif
+        { return abstract_iterator::operator--(0); }
+
+        virtual inline abstract_iterator
+        operator-=(const std::ptrdiff_t& n)
+        #if __cplusplus == 201103L
+        final
+        #endif
+        { return abstract_iterator::operator +=(n); }
+
+        virtual inline abstract_iterator operator--()
+        #if __cplusplus == 201103L
+        final
+        #endif
+        { return abstract_iterator::operator ++(); }
+
+        virtual inline abstract_iterator operator--(int)
+        #if __cplusplus == 201103L
+        final
+        #endif
+        { return abstract_iterator::operator ++(0); }
+
+        virtual inline const abstract_iterator
+        operator-(const std::ptrdiff_t& n) const
+        #if __cplusplus == 201103L
+        final
+        #endif
+        { return abstract_iterator::operator+(n); }
+
+    public: // comparission operators
+        inline bool operator>(const abstract_iterator& other)
+        #if __cplusplus == 201103L
+        final
+        #endif
+        { return abstract_iterator::operator<(other); }
+
+        inline bool operator<(const abstract_iterator& other)
+        #if __cplusplus == 201103L
+        final
+        #endif
+        { return abstract_iterator::operator>(other); }
+
+        inline bool operator>=(const abstract_iterator& other)
+        #if __cplusplus == 201103L
+        final
+        #endif
+        { return abstract_iterator::operator<=(other); }
+
+        inline bool operator<=(const abstract_iterator& other)
+        #if __cplusplus == 201103L
+        final
+        #endif
+        { return abstract_iterator::operator>=(other); }
+    };
+
+
+
+public: // actual iterators
+    /**
+     * @brief The NDarray1::iterator class
+     */
+    class iterator : public abstract_iterator
+    {
+    public:
+        // default and initializing constructors
+        iterator(T* ptr=nullptr)
+        : abstract_iterator(ptr) {}
+
+    public: // access operators
+        inline T& operator[](std::ptrdiff_t n)
+        { return const_cast<T&>(abstract_iterator::operator[](n)); }
+
+        inline T& operator*()
+        { return const_cast<T&>(abstract_iterator::operator*()); }
+
+        inline T* operator->()
+        { return const_cast<T&>(abstract_iterator::operator->()); }
+    };
+
+    /**
+     * @brief The NDarray1::reverse_iterator class
+     */
+    class reverse_iterator : public abstract_reverse_iterator
+    {
+    public:
+        // default and initializing constructors
+        reverse_iterator(T* ptr=nullptr)
+        : abstract_reverse_iterator(ptr) {}
+
+    public: // access operators
+        inline T& operator[](std::ptrdiff_t n)
+        { return const_cast<T&>(abstract_iterator::operator[](-n)); }
+
+        inline T& operator*()
+        { return const_cast<T&>(abstract_iterator::operator*()); }
+
+        inline T* operator->()
+        { return const_cast<T&>(abstract_iterator::operator->()); }
+    };
+
+    /**
+     * @brief The NDarray1::const_iterator class
+     */
+    class const_iterator : public abstract_iterator
+    {
+    public:
+        // default and initializing constructors
+        const_iterator(T* ptr=nullptr)
+        : abstract_iterator(ptr) {}
+
+    public: // access operators
+        inline const T& operator[](std::ptrdiff_t n)
+        { return (abstract_iterator::operator[](n)); }
+
+        inline const T& operator*()
+        { return (abstract_iterator::operator*()); }
+
+        inline const T* operator->()
+        { return (abstract_iterator::operator->()); }
+    };
+
+    /**
+     * @brief The NDarray1::const_reverse_iterator class
+     */
+    class const_reverse_iterator: public abstract_reverse_iterator
+    {
+    public:
+        // default and initializing constructors
+        const_reverse_iterator(T* ptr=nullptr)
+        : abstract_reverse_iterator(ptr) {}
+
+    public: // access operators
+        inline const T& operator[](std::ptrdiff_t n)
+        { return (abstract_iterator::operator[](-n)); }
+
+        inline const T& operator*()
+        { return (abstract_iterator::operator*()); }
+
+        inline const T* operator->()
+        { return (abstract_iterator::operator->()); }
+    };
+
+public: // iterator geters
+  iterator begin()
+  #if __cplusplus == 201103L
+  noexcept
+  #endif
+  { return iterator(array1<T>::v); }
+
+  iterator end()
+  #if __cplusplus == 201103L
+  noexcept
+  #endif
+  { return iterator(array1<T>::v + array1<T>::size); }
+
+  reverse_iterator rbegin()
+  #if __cplusplus == 201103L
+  noexcept
+  #endif
+  { return reverse_iterator(array1<T>::v + array1<T>::size); }
+
+  reverse_iterator rend()
+  #if __cplusplus == 201103L
+  noexcept
+  #endif
+  { return reverse_iterator(array1<T>::v); }
+
+  const_iterator begin() const
+  #if __cplusplus == 201103L
+  noexcept
+  #endif
+  { return const_iterator(array1<T>::v); }
+
+  const_iterator end() const
+  #if __cplusplus == 201103L
+  noexcept
+  #endif
+  { return const_iterator(array1<T>::v + array1<T>::size); }
+
+  #if __cplusplus == 201103L
+  const_iterator cbegin() const noexcept
+  { return const_iterator(array1<T>::v); }
+  
+  const_iterator cend() const noexcept
+  { return const_iterator(array1<T>::v + array1<T>::size); }
+  #endif
+
+  const_reverse_iterator rbegin() const
+  #if __cplusplus == 201103L
+  noexcept
+  #endif
+  { return const_reverse_iterator(array1<T>::v + array1<T>::size); }
+
+  const_reverse_iterator rend() const
+  #if __cplusplus == 201103L
+  noexcept
+  #endif
+  { return const_reverse_iterator(array1<T>::v); }
+
+  #if __cplusplus == 201103L
+  const_reverse_iterator crbegin() const noexcept
+  { return const_reverse_iterator(array1<T>::v + array1<T>::size); }
+
+  const_reverse_iterator crend() const noexcept
+  { return const_reverse_iterator(array1<T>::v); }
+  #endif
+}; // array1
 
 template<class T>
 void swaparray(T& A, T& B)

--- a/Array.h
+++ b/Array.h
@@ -29,6 +29,9 @@
 #include <climits>
 #include <cstdlib>
 #include <cerrno>
+#if __cplusplus => 201103L
+#include <initializer_list>
+#endif
 
 #if not defined NDEBUG and not defined __NOARRAY2OPT
 #define __NOARRAY2OPT
@@ -126,15 +129,42 @@ template<class T>
 class array1 {
 protected:
   T *v;
-  unsigned int size;
+  unsigned int _size;
   mutable int state;
 public:
+
+#if __cplusplus => 201103L
+  /**
+   * @brief array1 initializing constructur using initializer list
+   * @param il initializer list
+   */
+  array1(std::initializer_list<T> il)
+  : array1<T>(il.size())
+  { std::copy(il.begin(),il.end(),v); }
+#endif
+
+  /**
+   * @brief array1 constructor using random access iterators
+   */
+  template <typename InputIterator>
+  array1(InputIterator first, InputIterator last)
+  : array1<T>(last-first)
+  { std::copy(first,last,v); }
+
   enum alloc_state {unallocated=0, allocated=1, temporary=2, aligned=4};
-  virtual unsigned int Size() const {return size;}
+
+  /**
+   * @brief size STL style container size information
+   * @return
+   */
+  inline std::size_t size() const { return _size; }
+
+
+  virtual unsigned int Size() const {return size();}
 
 
   void CheckSize() const {
-    if(!test(allocated) && size == 0)
+    if(!test(allocated) && _size == 0)
       ArrayExit("Operation attempted on unallocated array"); 
   }
   void CheckEqual(int a, int b, unsigned int dim, unsigned int m) const {
@@ -153,10 +183,10 @@ public:
   void set(int flag) const {state |= flag;}
   void Activate(size_t align=0) {
     if(align) {
-      newAlign(v,size,align);
+      newAlign(v,_size,align);
       set(allocated | aligned);
     } else {
-      v=new T[size];
+      v=new T[_size];
       set(allocated);
     }
   }
@@ -166,18 +196,18 @@ public:
   }
   void Deallocate() const {
     if(test(allocated)) {
-      if(test(aligned)) deleteAlign(v,size);
+      if(test(aligned)) deleteAlign(v,_size);
       else delete [] v;
       state=unallocated;
     }
   }
-  void Dimension(unsigned int nx0) {size=nx0;}
+  void Dimension(unsigned int nx0) {_size=nx0;}
 
   void Dimension(unsigned int nx0, T *v0) {
     Dimension(nx0); v=v0; clear(allocated);
   }
   void Dimension(const array1<T>& A) {
-    Dimension(A.size,A.v); state=A.test(temporary);
+    Dimension(A._size,A.v); state=A.test(temporary);
   }
 
   void CheckActivate(size_t align=0) {
@@ -194,14 +224,14 @@ public:
     Allocate(nx0,align);
   }
   
-  array1() : v(NULL), size(0), state(unallocated) {}
-  array1(const void *) : size(0), state(unallocated) {}
+  array1() : v(NULL), _size(0), state(unallocated) {}
+  array1(const void *) : _size(0), state(unallocated) {}
   array1(unsigned int nx0, size_t align=0) : state(unallocated) {
     Allocate(nx0,align);
   }
   array1(unsigned int nx0, T *v0) : state(unallocated) {Dimension(nx0,v0);}
   array1(T *v0) : state(unallocated) {Dimension(INT_MAX,v0);}
-  array1(const array1<T>& A) : v(A.v), size(A.size),
+  array1(const array1<T>& A) : v(A.v), _size(A._size),
                                state(A.test(temporary)) {}
 
   virtual ~array1() {Deallocate();}
@@ -210,8 +240,7 @@ public:
   void Hold() {if(test(allocated)) {state=temporary;}}
   void Purge() const {if(test(temporary)) {Deallocate(); state=unallocated;}}
         
-  void Check(int i, int n, unsigned int dim, unsigned int m,
-             int o=0) const {
+  void Check(int i, int n, unsigned int dim, unsigned int m, int o=0) const {
     if(i < 0 || i >= n) {
       std::ostringstream buf;
       buf << "Array" << dim << " index ";
@@ -228,7 +257,7 @@ public:
     }
   }
         
-  unsigned int Nx() const {return size;}
+  unsigned int Nx() const {return _size;}
   
 #ifdef NDEBUG
   typedef T *opt;
@@ -237,49 +266,49 @@ public:
   typedef array1<T> opt;
 #endif
   
-  T& operator [] (int ix) const {__check(ix,size,1,1); return v[ix];}
-  T& operator () (int ix) const {__check(ix,size,1,1); return v[ix];}
+  T& operator [] (int ix) const {__check(ix,_size,1,1); return v[ix];}
+  T& operator () (int ix) const {__check(ix,_size,1,1); return v[ix];}
   T* operator () () const {return v;}
   operator T* () const {return v;}
         
-  array1<T> operator + (int i) const {return array1<T>(size-i,v+i);}
+  array1<T> operator + (int i) const {return array1<T>(_size-i,v+i);}
         
   void Load(T a) const {
     array1<T>::__checkSize();
-    for(unsigned int i=0; i < size; i++) v[i]=a;
+    for(unsigned int i=0; i < _size; i++) v[i]=a;
   }
   void Load(const T *a) const {
-    for(unsigned int i=0; i < size; i++) v[i]=a[i];
+    for(unsigned int i=0; i < _size; i++) v[i]=a[i];
   }
   void Store(T *a) const {
-    for(unsigned int i=0; i < size; i++) a[i]=v[i];
+    for(unsigned int i=0; i < _size; i++) a[i]=v[i];
   }
   void Set(T *a) {v=a; clear(allocated);}
   T Min() {
-    if(size == 0)
+    if(_size == 0)
       ArrayExit("Cannot take minimum of empty array"); 
     T min=v[0];
-    for(unsigned int i=1; i < size; i++) if(v[i] < min) min=v[i];
+    for(unsigned int i=1; i < _size; i++) if(v[i] < min) min=v[i];
     return min;
   }
   T Max() {
-    if(size == 0)
+    if(_size == 0)
       ArrayExit("Cannot take maximum of empty array"); 
     T max=v[0];
-    for(unsigned int i=1; i < size; i++) if(v[i] > max) max=v[i];
+    for(unsigned int i=1; i < _size; i++) if(v[i] > max) max=v[i];
     return max;
   }
   
   std::istream& Input (std::istream &s) const {
     __checkSize();
-    for(unsigned int i=0; i < size; i++) s >> v[i];
+    for(unsigned int i=0; i < _size; i++) s >> v[i];
     return s;
   }
         
   array1<T>& operator = (T a) {Load(a); return *this;}
   array1<T>& operator = (const T *a) {Load(a); return *this;}
   array1<T>& operator = (const array1<T>& A) {
-    if(size != A.Size()) {
+    if(_size != A.Size()) {
       Deallocate();
       Allocate(A.Size());
     }
@@ -290,51 +319,51 @@ public:
         
   array1<T>& operator += (const array1<T>& A) {
     __checkSize();
-    for(unsigned int i=0; i < size; i++) v[i] += A(i);
+    for(unsigned int i=0; i < _size; i++) v[i] += A(i);
     return *this;
   }
   array1<T>& operator -= (const array1<T>& A) {
     __checkSize();
-    for(unsigned int i=0; i < size; i++) v[i] -= A(i);
+    for(unsigned int i=0; i < _size; i++) v[i] -= A(i);
     return *this;
   }
   array1<T>& operator *= (const array1<T>& A) {
     __checkSize();
-    for(unsigned int i=0; i < size; i++) v[i] *= A(i);
+    for(unsigned int i=0; i < _size; i++) v[i] *= A(i);
     return *this;
   }
   array1<T>& operator /= (const array1<T>& A) {
     __checkSize();
-    for(unsigned int i=0; i < size; i++) v[i] /= A(i);
+    for(unsigned int i=0; i < _size; i++) v[i] /= A(i);
     return *this;
   }
         
   array1<T>& operator += (T a) {
     __checkSize();
-    for(unsigned int i=0; i < size; i++) v[i] += a;
+    for(unsigned int i=0; i < _size; i++) v[i] += a;
     return *this;
   }
   array1<T>& operator -= (T a) {
     __checkSize();
-    for(unsigned int i=0; i < size; i++) v[i] -= a;
+    for(unsigned int i=0; i < _size; i++) v[i] -= a;
     return *this;
   }
   array1<T>& operator *= (T a) {
     __checkSize();
-    for(unsigned int i=0; i < size; i++) v[i] *= a;
+    for(unsigned int i=0; i < _size; i++) v[i] *= a;
     return *this;
   }
   array1<T>& operator /= (T a) {
     __checkSize();
     T ainv=1.0/a;
-    for(unsigned int i=0; i < size; i++) v[i] *= ainv;
+    for(unsigned int i=0; i < _size; i++) v[i] *= ainv;
     return *this;
   }
         
   double L1() const {
     __checkSize();
     double norm=0.0;
-    for(unsigned int i=0; i < size; i++) norm += abs(v[i]);
+    for(unsigned int i=0; i < _size; i++) norm += abs(v[i]);
     return norm;
   }
 #ifdef __ArrayExtensions
@@ -697,13 +726,13 @@ public: // iterator geters
   #if __cplusplus == 201103L
   noexcept
   #endif
-  { return iterator(array1<T>::v + array1<T>::size); }
+  { return iterator(array1<T>::v + array1<T>::_size); }
 
   reverse_iterator rbegin()
   #if __cplusplus == 201103L
   noexcept
   #endif
-  { return reverse_iterator(array1<T>::v + array1<T>::size); }
+  { return reverse_iterator(array1<T>::v + array1<T>::_size); }
 
   reverse_iterator rend()
   #if __cplusplus == 201103L
@@ -721,7 +750,7 @@ public: // iterator geters
   #if __cplusplus == 201103L
   noexcept
   #endif
-  { return const_iterator(array1<T>::v + array1<T>::size); }
+  { return const_iterator(array1<T>::v + array1<T>::_size); }
 
   #if __cplusplus == 201103L
   const_iterator cbegin() const noexcept
@@ -735,7 +764,7 @@ public: // iterator geters
   #if __cplusplus == 201103L
   noexcept
   #endif
-  { return const_reverse_iterator(array1<T>::v + array1<T>::size); }
+  { return const_reverse_iterator(array1<T>::v + array1<T>::_size); }
 
   const_reverse_iterator rend() const
   #if __cplusplus == 201103L
@@ -811,7 +840,7 @@ public:
   inline void Dimension(unsigned int nx0, unsigned int ny0) {
     nx=nx0;
     ny=ny0;
-    array1<T>::size=nx*ny;
+    array1<T>::_size=nx*ny;
   }
   void Dimension(unsigned int nx0, unsigned int ny0, T *v0) {
     Dimension(nx0,ny0);
@@ -851,7 +880,7 @@ public:
     return this->v[ix*ny+iy];
   }
   T& operator () (int i) const {
-    array1<T>::__check(i,this->size,2,0);
+    array1<T>::__check(i,this->_size,2,0);
     return this->v[i];
   }
   T* operator () () const {return this->v;}
@@ -868,12 +897,12 @@ public:
         
   array2<T>& operator += (const array2<T>& A) {
     array1<T>::__checkSize();
-    for(unsigned int i=0; i < this->size; i++) this->v[i] += A(i);
+    for(unsigned int i=0; i < this->_size; i++) this->v[i] += A(i);
     return *this;
   }
   array2<T>& operator -= (const array2<T>& A) {
     array1<T>::__checkSize();
-    for(unsigned int i=0; i < this->size; i++) this->v[i] -= A(i);
+    for(unsigned int i=0; i < this->_size; i++) this->v[i] -= A(i);
     return *this;
   }
   array2<T>& operator *= (const array2<T>& A);
@@ -881,18 +910,18 @@ public:
   array2<T>& operator += (T a) {
     array1<T>::__checkSize();
     unsigned int inc=ny+1;
-    for(unsigned int i=0; i < this->size; i += inc) this->v[i] += a;
+    for(unsigned int i=0; i < this->_size; i += inc) this->v[i] += a;
     return *this;
   }
   array2<T>& operator -= (T a) {
     array1<T>::__checkSize();
     unsigned int inc=ny+1;
-    for(unsigned int i=0; i < this->size; i += inc) this->v[i] -= a;
+    for(unsigned int i=0; i < this->_size; i += inc) this->v[i] -= a;
     return *this;
   }
   array2<T>& operator *= (T a) {
     array1<T>::__checkSize();
-    for(unsigned int i=0; i < this->size; i++) this->v[i] *= a;
+    for(unsigned int i=0; i < this->_size; i++) this->v[i] *= a;
     return *this;
   }
   
@@ -900,7 +929,7 @@ public:
     this->Load((T) 0);
     array1<T>::__checkSize();
     unsigned int inc=ny+1;
-    for(unsigned int i=0; i < this->size; i += inc) this->v[i]=(T) 1;
+    for(unsigned int i=0; i < this->_size; i += inc) this->v[i]=(T) 1;
   }
 };
 
@@ -939,7 +968,7 @@ public:
   
   void Dimension(unsigned int nx0, unsigned int ny0, unsigned int nz0) {
     nx=nx0; ny=ny0; nz=nz0; nyz=ny*nz;
-    this->size=nx*nyz;
+    this->_size=nx*nyz;
   }
   void Dimension(unsigned int nx0, unsigned int ny0, unsigned int nz0, T *v0) {
     Dimension(nx0,ny0,nz0);
@@ -977,7 +1006,7 @@ public:
     return this->v[ix*nyz+iy*nz+iz];
   }
   T& operator () (int i) const {
-    array1<T>::__check(i,this->size,3,0);
+    array1<T>::__check(i,this->_size,3,0);
     return this->v[i];
   }
   T* operator () () const {return this->v;}
@@ -995,25 +1024,25 @@ public:
         
   array3<T>& operator += (array3<T>& A) {
     array1<T>::__checkSize();
-    for(unsigned int i=0; i < this->size; i++) this->v[i] += A(i);
+    for(unsigned int i=0; i < this->_size; i++) this->v[i] += A(i);
     return *this;
   }
   array3<T>& operator -= (array3<T>& A) {
     array1<T>::__checkSize();
-    for(unsigned int i=0; i < this->size; i++) this->v[i] -= A(i);
+    for(unsigned int i=0; i < this->_size; i++) this->v[i] -= A(i);
     return *this;
   }
         
   array3<T>& operator += (T a) {
     array1<T>::__checkSize();
     unsigned int inc=nyz+nz+1;
-    for(unsigned int i=0; i < this->size; i += inc) this->v[i] += a;
+    for(unsigned int i=0; i < this->_size; i += inc) this->v[i] += a;
     return *this;
   }
   array3<T>& operator -= (T a) {
     array1<T>::__checkSize();
     unsigned int inc=nyz+nz+1;
-    for(unsigned int i=0; i < this->size; i += inc) this->v[i] -= a;
+    for(unsigned int i=0; i < this->_size; i += inc) this->v[i] -= a;
     return *this;
   }
 };
@@ -1060,7 +1089,7 @@ public:
   void Dimension(unsigned int nx0, unsigned int ny0, unsigned int nz0,
                  unsigned int nw0) {
     nx=nx0; ny=ny0; nz=nz0; nw=nw0; nzw=nz*nw; nyzw=ny*nzw;
-    this->size=nx*nyzw;
+    this->_size=nx*nyzw;
   }
   void Dimension(unsigned int nx0, unsigned int ny0, unsigned int nz0,
                  unsigned int nw0, T *v0) {
@@ -1100,7 +1129,7 @@ public:
     return this->v[ix*nyzw+iy*nzw+iz*nw+iw];
   }
   T& operator () (int i) const {
-    array1<T>::__check(i,this->size,4,0);
+    array1<T>::__check(i,this->_size,4,0);
     return this->v[i];
   }
   T* operator () () const {return this->v;}
@@ -1119,25 +1148,25 @@ public:
         
   array4<T>& operator += (array4<T>& A) {
     array1<T>::__checkSize();
-    for(unsigned int i=0; i < this->size; i++) this->v[i] += A(i);
+    for(unsigned int i=0; i < this->_size; i++) this->v[i] += A(i);
     return *this;
   }
   array4<T>& operator -= (array4<T>& A) {
     array1<T>::__checkSize();
-    for(unsigned int i=0; i < this->size; i++) this->v[i] -= A(i);
+    for(unsigned int i=0; i < this->_size; i++) this->v[i] -= A(i);
     return *this;
   }
         
   array4<T>& operator += (T a) {
     array1<T>::__checkSize();
     unsigned int inc=nyzw+nzw+nw+1;
-    for(unsigned int i=0; i < this->size; i += inc) this->v[i] += a;
+    for(unsigned int i=0; i < this->_size; i += inc) this->v[i] += a;
     return *this;
   }
   array4<T>& operator -= (T a) {
     array1<T>::__checkSize();
     unsigned int inc=nyzw+nzw+nw+1;
-    for(unsigned int i=0; i < this->size; i += inc) this->v[i] -= a;
+    for(unsigned int i=0; i < this->_size; i += inc) this->v[i] -= a;
     return *this;
   }
 };
@@ -1189,7 +1218,7 @@ public:
                  unsigned int nw0, unsigned int nv0) {
     nx=nx0; ny=ny0; nz=nz0; nw=nw0; nv=nv0; nwv=nw*nv; nzwv=nz*nwv;
     nyzwv=ny*nzwv;
-    this->size=nx*nyzwv;
+    this->_size=nx*nyzwv;
   }
   void Dimension(unsigned int nx0, unsigned int ny0, unsigned int nz0,
                  unsigned int nw0, unsigned int nv0, T *v0) {
@@ -1233,7 +1262,7 @@ public:
     return this->v[ix*nyzwv+iy*nzwv+iz*nwv+iw*nv+iv];
   }
   T& operator () (int i) const {
-    array1<T>::__check(i,this->size,5,0);
+    array1<T>::__check(i,this->_size,5,0);
     return this->v[i];
   }
   T* operator () () const {return this->v;}
@@ -1253,25 +1282,25 @@ public:
         
   array5<T>& operator += (array5<T>& A) {
     array1<T>::__checkSize();
-    for(unsigned int i=0; i < this->size; i++) this->v[i] += A(i);
+    for(unsigned int i=0; i < this->_size; i++) this->v[i] += A(i);
     return *this;
   }
   array5<T>& operator -= (array5<T>& A) {
     array1<T>::__checkSize();
-    for(unsigned int i=0; i < this->size; i++) this->v[i] -= A(i);
+    for(unsigned int i=0; i < this->_size; i++) this->v[i] -= A(i);
     return *this;
   }
         
   array5<T>& operator += (T a) {
     array1<T>::__checkSize();
     unsigned int inc=nyzwv+nzwv+nwv+nv+1;
-    for(unsigned int i=0; i < this->size; i += inc) this->v[i] += a;
+    for(unsigned int i=0; i < this->_size; i += inc) this->v[i] += a;
     return *this;
   }
   array5<T>& operator -= (T a) {
     array1<T>::__checkSize();
     unsigned int inc=nyzwv+nzwv+nwv+nv+1;
-    for(unsigned int i=0; i < this->size; i += inc) this->v[i] -= a;
+    for(unsigned int i=0; i < this->_size; i += inc) this->v[i] -= a;
     return *this;
   }
 };
@@ -1320,7 +1349,7 @@ public:
   using array1<T>::Dimension;
   
   void Dimension(unsigned int nx0, int ox0=0) {
-    this->size=nx0;
+    this->_size=nx0;
     ox=ox0;
     Offsets();
   }
@@ -1330,7 +1359,7 @@ public:
     this->clear(this->allocated);
   }
   void Dimension(const Array1<T>& A) {
-    Dimension(A.size,A.v,A.ox); this->state=A.test(this->temporary);
+    Dimension(A._size,A.v,A.ox); this->state=A.test(this->temporary);
   }
 
   void Allocate(unsigned int nx0, int ox0=0, size_t align=0) {
@@ -1361,25 +1390,25 @@ public:
   typedef Array1<T> opt;
 #endif  
   
-  T& operator [] (int ix) const {__check(ix,this->size,ox,1,1); return voff[ix];}
-  T& operator () (int i) const {__check(i,this->size,0,1,1); return this->v[i];}
+  T& operator [] (int ix) const {__check(ix,this->_size,ox,1,1); return voff[ix];}
+  T& operator () (int i) const {__check(i,this->_size,0,1,1); return this->v[i];}
   T* operator () () const {return this->v;}
   operator T* () const {return this->v;}
         
-  Array1<T> operator + (int i) const {return Array1<T>(this->size-i,this->v+i,ox);}
+  Array1<T> operator + (int i) const {return Array1<T>(this->_size-i,this->v+i,ox);}
   void Set(T *a) {this->v=a; Offsets(); this->clear(this->allocated);}
         
   Array1<T>& operator = (T a) {this->Load(a); return *this;}
   Array1<T>& operator = (const T *a) {this->Load(a); return *this;}
   Array1<T>& operator = (const Array1<T>& A) {
-    array1<T>::__checkEqual(this->size,A.Size(),1,1);
+    array1<T>::__checkEqual(this->_size,A.Size(),1,1);
     array1<T>::__checkEqual(ox,A.Ox(),1,1);
     this->Load(A());
     A.Purge();
     return *this;
   }
   Array1<T>& operator = (const array1<T>& A) {
-    array1<T>::__checkEqual(this->size,A.Size(),1,1);
+    array1<T>::__checkEqual(this->_size,A.Size(),1,1);
     array1<T>::__checkEqual(ox,0,1,1);
     this->Load(A());
     A.Purge();
@@ -1414,7 +1443,7 @@ public:
   
   void Dimension(unsigned int nx0, unsigned int ny0, int ox0=0, int oy0=0) {
     this->nx=nx0; this->ny=ny0;
-    this->size=this->nx*this->ny;
+    this->_size=this->nx*this->ny;
     ox=ox0; oy=oy0;
     Offsets();
   }
@@ -1458,7 +1487,7 @@ public:
     return voff[ix*(int) this->ny+iy];
   }
   T& operator () (int i) const {
-    Array1<T>::__check(i,this->size,0,2,0);
+    Array1<T>::__check(i,this->_size,0,2,0);
     return this->v[i];
   }
   T* operator () () const {return this->v;}
@@ -1508,7 +1537,7 @@ public:
   void Dimension(unsigned int nx0, unsigned int ny0, unsigned int nz0,
                  int ox0=0, int oy0=0, int oz0=0) {
     this->nx=nx0; this->ny=ny0; this->nz=nz0; this->nyz=this->ny*this->nz;
-    this->size=this->nx*this->nyz;
+    this->_size=this->nx*this->nyz;
     ox=ox0; oy=oy0; oz=oz0;
     Offsets();
   }
@@ -1547,7 +1576,7 @@ public:
     return voff[ix*(int) this->nyz+iy*(int) this->nz+iz];
   }
   T& operator () (int i) const {
-    Array1<T>::__check(i,this->size,0,3,0);
+    Array1<T>::__check(i,this->_size,0,3,0);
     return this->v[i];
   }
   T* operator () () const {return this->v;}
@@ -1604,7 +1633,7 @@ public:
                  int ox0=0, int oy0=0, int oz0=0, int ow0=0) {
     this->nx=nx0; this->ny=ny0; this->nz=nz0; this->nw=nw0;
     this->nzw=this->nz*this->nw; this->nyzw=this->ny*this->nzw;
-    this->size=this->nx*this->nyzw;
+    this->_size=this->nx*this->nyzw;
     ox=ox0; oy=oy0; oz=oz0; ow=ow0;
     Offsets();
   }
@@ -1649,7 +1678,7 @@ public:
     return voff[ix*(int) this->nyzw+iy*(int) this->nzw+iz*(int) this->nw+iw];
   }
   T& operator () (int i) const {
-    Array1<T>::__check(i,this->size,0,4,0);
+    Array1<T>::__check(i,this->_size,0,4,0);
     return this->v[i];
   }
   T* operator () () const {return this->v;}
@@ -1716,7 +1745,7 @@ public:
     this->nx=nx0; this->ny=ny0; this->nz=nz0; this->nw=nw0; this->nv=nv0;
     this->nwv=this->nw*this->nv; this->nzwv=this->nz*this->nwv;
     this->nyzwv=this->ny*this->nzwv;
-    this->size=this->nx*this->nyzwv;
+    this->_size=this->nx*this->nyzwv;
     ox=ox0; oy=oy0; oz=oz0; ow=ow0; ov=ov0;
     Offsets();
   }
@@ -1764,7 +1793,7 @@ public:
                 +iw*(int) this->nv+iv];
   }
   T& operator () (int i) const {
-    Array1<T>::__check(i,this->size,0,5,0);
+    Array1<T>::__check(i,this->_size,0,5,0);
     return this->v[i];
   }
   T* operator () () const {return this->v;}


### PR DESCRIPTION
I added iterators to Array::array1 and added two examples in Array.cc. Where applicable, C++11 preprocessor switches mimic the behavior of the different versions of STL.