### PR TITLE
add `using namespace utils` to resolve `doubleAlign`

### DIFF
--- a/fftw++.h
+++ b/fftw++.h
@@ -84,6 +84,7 @@ typedef std::complex<double> Complex;
 namespace fftwpp {
 
 // Obsolete names:
+using namespace utils; // defined in align.h
 #define FFTWComplex ComplexAlign
 #define FFTWdouble doubleAlign
 #define FFTWdelete deleteAlign


### PR DESCRIPTION
old version causes error
```
fftw++.h:92:20: error: ‘doubleAlign’ is not a member of ‘fftwpp’; did you mean ‘utils::doubleAlign’?
   92 | #define FFTWdouble doubleAlign
      |                    ^~~~~~~~~~~
```
`#define FFTWdouble utils::doubleAlign` is not possible
(throws `error: ‘fftwpp::utils’ has not been declared`)
so we use `using namespace utils;`